### PR TITLE
[feat]メインページの外観作成

### DIFF
--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { AiOutlineTwitter } from 'react-icons/ai'
 
 const Footer: React.FC = () => {
   return (
-    <footer className='footer absolute bottom-0 items-center bg-neutral p-4 text-neutral-content'>
+    <footer className='footer bottom-0 items-center bg-neutral p-4 text-neutral-content md:absolute'>
       <div className='grid-flow-col items-center'>
         <Image src='/logo_images.png' width={36} height={36} alt='logo' />
         <p>Copyright © 2023 - NUTMEG</p>

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,28 +1,29 @@
-import classame from "classnames";
 import Image from 'next/image'
-import { AiOutlineTwitter,AiOutlineInstagram } from 'react-icons/ai'
+import { AiOutlineTwitter } from 'react-icons/ai'
 
 const Footer: React.FC = () => {
+  return (
+    <footer className='footer bottom-0 items-center bg-neutral p-4 text-neutral-content'>
+      <div className='grid-flow-col items-center'>
+        <Image src='/logo_images.png' width={36} height={36} alt='logo' />
+        <p>Copyright © 2023 - NUTMEG</p>
+      </div>
+      <div className='grid-flow-col gap-4 md:place-self-center md:justify-self-end'>
+        <a
+          className='hover:scale-125'
+          href='https://twitter.com/nutfes_nutmeg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor'
+        >
+          <AiOutlineTwitter size='24' />
+        </a>
+        <a className='link-hover link hover:scale-125' href='https://blog.nutmeg.cloud/'>
+          Blog
+        </a>
+        <a className='link-hover link hover:scale-125' href='https://www.nutfes.net/'>
+          HP
+        </a>
+      </div>
+    </footer>
+  )
+}
 
-    return (
-        <footer className="footer items-center p-4 bg-neutral text-neutral-content absolute bottom-0">
-            <div className="items-center grid-flow-col">
-                <Image src="/logo_images.png" width={36} height={36} alt="logo"/>
-                <p>Copyright © 2023 - NUTMEG</p>
-            </div>
-            <div className="grid-flow-col gap-4 md:place-self-center md:justify-self-end">
-                <a className="hover:scale-125" href="https://twitter.com/nutfes_nutmeg?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">
-                    <AiOutlineTwitter size="24"/>
-                </a>
-                <a className="link link-hover hover:scale-125" href="https://blog.nutmeg.cloud/">
-                    Blog
-                </a>
-                <a className="link link-hover hover:scale-125" href="https://www.nutfes.net/">
-                    HP
-                </a>
-            </div>
-        </footer>
-    )
-};
-
-export default Footer;
+export default Footer

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { AiOutlineTwitter } from 'react-icons/ai'
 
 const Footer: React.FC = () => {
   return (
-    <footer className='footer bottom-0 items-center bg-neutral p-4 text-neutral-content'>
+    <footer className='footer absolute bottom-0 items-center bg-neutral p-4 text-neutral-content'>
       <div className='grid-flow-col items-center'>
         <Image src='/logo_images.png' width={36} height={36} alt='logo' />
         <p>Copyright © 2023 - NUTMEG</p>

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,8 +1,7 @@
-import { InputProps } from './Input.types';
-import classNames from 'classnames';
+import { InputProps } from './Input.types'
 
 const Input: React.FC<InputProps> = (props) => {
-  return <input className="input input-bordered" {...props} />;
-};
+  return <input className='input input-bordered bg-white' {...props} />
+}
 
-export default Input;
+export default Input

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -1,15 +1,12 @@
-import { TextAreaProps } from "./TextArea.types";
-import classNames from "classnames";
+import classNames from 'classnames'
+import { TextAreaProps } from './TextArea.types'
 
-const TextArea: React.FC<TextAreaProps> = ({
-    bordered,
-    ghosted,
-  }) => {
-    const borderedClass = bordered ? 'textarea-bordered' : '';
-    const ghostedClass = ghosted ? 'testarea-ghost' : '';
-    return (
-      <textarea className={classNames('textarea', borderedClass, ghostedClass)}/>
-    );
-  };
+const TextArea: React.FC<TextAreaProps> = ({ bordered, ghosted }) => {
+  const borderedClass = bordered ? 'textarea-bordered' : ''
+  const ghostedClass = ghosted ? 'testarea-ghost' : ''
+  return (
+    <textarea className={classNames('textarea bg-white', borderedClass, ghostedClass)} />
+  )
+}
 
-  export default TextArea;
+export default TextArea

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,14 +5,20 @@ import { MainLayout } from '@/components/layout/MainLayout'
 export default function Home() {
   return (
     <MainLayout>
-      <div className='m-auto mt-20 hidden w-4/5 grid-cols-4 gap-5 md:grid'>
-        <div className='col-span-2 my-5 ml-28 flex  w-80 gap-4'>
-          <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP1</p>
-          <p className='my-auto text-xl underline'>イベント名を入力</p>
+      <div className='m-auto mt-20 hidden w-4/5 grid-cols-4 gap-4 md:grid'>
+        <div className='col-span-2 ml-28 w-80 gap-4'>
+          <div className='flex gap-4'>
+            <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP1</p>
+            <p className='my-auto text-xl font-semibold'>イベント名を入力</p>
+          </div>
+          <p className='ml-16 text-sm'>※飲み会、会議など</p>
         </div>
-        <div className='col-span-2 my-5 flex gap-4'>
-          <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP3</p>
-          <p className='my-auto text-xl underline'>日程の入力</p>
+        <div className='col-span-2 ml-8'>
+          <div className='flex gap-4'>
+            <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP3</p>
+            <p className='my-auto text-xl font-semibold'>日程の入力</p>
+          </div>
+          <p className='ml-16 text-sm'>※日程調整日を選択</p>
         </div>
         <div className='col-span-2 ml-36'>
           <Input />
@@ -20,15 +26,18 @@ export default function Home() {
         <div className='col-span-2 row-span-3 m-auto h-48 w-1/2 rounded-lg bg-accent'>
           カレンダー
         </div>
-        <div className='col-span-2 my-5 ml-28 flex w-80 gap-4'>
-          <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>
-          <p className='my-auto text-xl underline'>メモを入力</p>
+        <div className='col-span-2 ml-28 w-80'>
+          <div className='flex gap-4'>
+            <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP2</p>
+            <p className='my-auto text-xl font-semibold'>メモを入力(任意)</p>
+          </div>
+          <p className='ml-16 text-sm'>※出欠〆切は◯日</p>
         </div>
         <div className='col-span-2 ml-36'>
           <TextArea bordered={true} ghosted={false} />
         </div>
       </div>
-      <div className='mt-16 flex justify-center'>
+      <div className='mt-16 flex justify-center font-semibold'>
         <Button>調整ちゃんを作成</Button>
       </div>
     </MainLayout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,22 @@
-import { Inter } from "next/font/google";
-import { MainLayout } from "@/components/layout/MainLayout";
-const inter = Inter({ subsets: ["latin"] });
-
+import { Button, Input } from '@/components/common'
+import { MainLayout } from '@/components/layout/MainLayout'
 
 export default function Home() {
-  return <MainLayout>hello</MainLayout>;
-};
+  return (
+    <MainLayout>
+      <div className='mx-auto my-10 flex w-80 flex-wrap justify-center gap-4'>
+        <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP1</p>
+        <p className='my-auto flex-wrap text-xl underline'>イベント名を入力</p>
+        <Input></Input>
+      </div>
+      <div className='my-4 flex justify-center gap-4'>
+        <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>
+        <p className='my-auto flex-wrap text-xl underline'>日程の入力</p>
+      </div>
+      <div className='m-auto h-96 w-1/2 rounded-lg bg-accent text-center'>カレンダー</div>
+      <div className='mb-10 mt-5 flex justify-center'>
+        <Button>作成</Button>
+      </div>
+    </MainLayout>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,12 +6,12 @@ export default function Home() {
     <MainLayout>
       <div className='mx-auto my-10 flex w-80 flex-wrap justify-center gap-4'>
         <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP1</p>
-        <p className='my-auto flex-wrap text-xl underline'>イベント名を入力</p>
+        <p className='my-auto text-xl underline'>イベント名を入力</p>
         <Input></Input>
       </div>
       <div className='my-4 flex justify-center gap-4'>
         <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>
-        <p className='my-auto flex-wrap text-xl underline'>日程の入力</p>
+        <p className='my-auto text-xl underline'>日程の入力</p>
       </div>
       <div className='m-auto h-96 w-1/2 rounded-lg bg-accent text-center'>カレンダー</div>
       <div className='mb-10 mt-5 flex justify-center'>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
                 </p>
                 <p className='text-xl font-semibold'>イベント名を入力</p>
               </div>
-              <p className='text-sm'>※飲み会、会議など</p>
+              <p className='ml-4 text-sm'>※飲み会、会議など</p>
               <Input />
             </div>
             <div className='divider' />
@@ -26,7 +26,7 @@ export default function Home() {
                 </p>
                 <p className='text-xl font-semibold'>メモを入力（任意）</p>
               </div>
-              <p className='text-sm'>※飲み会、会議など</p>
+              <p className='ml-4 text-sm'>※飲み会、会議など</p>
               <TextArea bordered={true} ghosted={false} />
               <div className='divider md:hidden' />
             </div>
@@ -39,7 +39,7 @@ export default function Home() {
                 </p>
                 <p className='text-xl font-semibold'>日付を入力</p>
               </div>
-              <p className='text-sm'>※飲み会、会議など</p>
+              <p className='ml-4 text-sm'>※候補日時を選択</p>
               <div>ここにカレンダー</div>
             </div>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,23 +5,31 @@ import { MainLayout } from '@/components/layout/MainLayout'
 export default function Home() {
   return (
     <MainLayout>
-      <div className='mx-auto my-10 flex w-80 flex-wrap justify-center gap-4'>
-        <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP1</p>
-        <p className='my-auto text-xl underline'>イベント名を入力</p>
-        <Input />
+      <div className='m-auto mt-20 hidden w-4/5 grid-cols-4 gap-5 md:grid'>
+        <div className='col-span-2 my-5 ml-28 flex  w-80 gap-4'>
+          <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP1</p>
+          <p className='my-auto text-xl underline'>イベント名を入力</p>
+        </div>
+        <div className='col-span-2 my-5 flex gap-4'>
+          <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP3</p>
+          <p className='my-auto text-xl underline'>日程の入力</p>
+        </div>
+        <div className='col-span-2 ml-36'>
+          <Input />
+        </div>
+        <div className='col-span-2 row-span-3 m-auto h-48 w-1/2 rounded-lg bg-accent'>
+          カレンダー
+        </div>
+        <div className='col-span-2 my-5 ml-28 flex w-80 gap-4'>
+          <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>
+          <p className='my-auto text-xl underline'>メモを入力</p>
+        </div>
+        <div className='col-span-2 ml-36'>
+          <TextArea bordered={true} ghosted={false} />
+        </div>
       </div>
-      <div className='mx-auto my-10 flex w-80 flex-wrap justify-center gap-4'>
-        <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>
-        <p className='my-auto text-xl underline'>メモを入力</p>
-        <TextArea bordered={true} ghosted={false} />
-      </div>
-      <div className='my-4 flex justify-center gap-4'>
-        <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP3</p>
-        <p className='my-auto text-xl underline'>日程の入力</p>
-      </div>
-      <div className='m-auto h-96 w-1/2 rounded-lg bg-accent text-center'>カレンダー</div>
-      <div className='mb-10 mt-5 flex justify-center'>
-        <Button>作成</Button>
+      <div className='mt-16 flex justify-center'>
+        <Button>調整ちゃんを作成</Button>
       </div>
     </MainLayout>
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,64 +5,46 @@ import { MainLayout } from '@/components/layout/MainLayout'
 export default function Home() {
   return (
     <MainLayout>
-      <div className='m-auto mt-20 hidden w-4/5 grid-cols-4 gap-4 md:grid'>
-        <div className='col-span-2 ml-28 w-80 gap-4'>
-          <div className='flex gap-4'>
-            <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP1</p>
-            <p className='my-auto text-xl font-semibold'>イベント名を入力</p>
+      <div className='my-10 flex flex-col items-center gap-16 md:my-16'>
+        <div className='m-auto flex w-4/5 flex-wrap md:flex-nowrap md:gap-16'>
+          <div className='flex flex-col md:w-1/2'>
+            <div className='flex flex-col gap-2'>
+              <div className='flex items-center gap-4'>
+                <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>
+                  STEP1
+                </p>
+                <p className='text-xl font-semibold'>イベント名を入力</p>
+              </div>
+              <p className='text-sm'>※飲み会、会議など</p>
+              <Input />
+            </div>
+            <div className='divider' />
+            <div className='flex flex-col gap-2'>
+              <div className='flex items-center gap-4'>
+                <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>
+                  STEP2
+                </p>
+                <p className='text-xl font-semibold'>メモを入力（任意）</p>
+              </div>
+              <p className='text-sm'>※飲み会、会議など</p>
+              <TextArea bordered={true} ghosted={false} />
+              <div className='divider md:hidden' />
+            </div>
           </div>
-          <p className='ml-16 text-sm'>※飲み会、会議など</p>
-        </div>
-        <div className='col-span-2 ml-8'>
-          <div className='flex gap-4'>
-            <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP3</p>
-            <p className='my-auto text-xl font-semibold'>日程の入力</p>
+          <div className='flex flex-col md:w-1/2'>
+            <div className='flex flex-col gap-2'>
+              <div className='flex items-center gap-4'>
+                <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>
+                  STEP3
+                </p>
+                <p className='text-xl font-semibold'>日付を入力</p>
+              </div>
+              <p className='text-sm'>※飲み会、会議など</p>
+              <div>ここにカレンダー</div>
+            </div>
           </div>
-          <p className='ml-16 text-sm'>※日程調整日を選択</p>
         </div>
-        <div className='col-span-2 ml-36'>
-          <Input />
-        </div>
-        <div className='col-span-2 row-span-3 m-auto h-48 w-1/2 rounded-lg bg-accent'>
-          カレンダー
-        </div>
-        <div className='col-span-2 ml-28 w-80'>
-          <div className='flex gap-4'>
-            <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP2</p>
-            <p className='my-auto text-xl font-semibold'>メモを入力(任意)</p>
-          </div>
-          <p className='ml-16 text-sm'>※出欠〆切は◯日</p>
-        </div>
-        <div className='col-span-2 ml-36'>
-          <TextArea bordered={true} ghosted={false} />
-        </div>
-      </div>
-      <div className='m-auto mt-5 block w-4/5 md:hidden'>
-        <div className='flex gap-4'>
-          <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP1</p>
-          <p className='my-auto text-xl font-semibold'>イベント名を入力</p>
-        </div>
-        <p className='ml-16 text-sm'>※飲み会、会議など</p>
-        <div className='ml-10 mt-2'>
-          <Input />
-        </div>
-        <div className='mt-4 flex gap-4'>
-          <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP2</p>
-          <p className='my-auto text-xl font-semibold'>メモを入力(任意)</p>
-        </div>
-        <p className='ml-16 text-sm'>※出欠〆切は◯日</p>
-        <div className='ml-10 mt-2'>
-          <TextArea bordered={true} ghosted={false} />
-        </div>
-        <div className='mt-4 flex gap-4'>
-          <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP3</p>
-          <p className='my-auto text-xl font-semibold'>日程の入力</p>
-        </div>
-        <p className='ml-16 text-sm'>※日程調整日を選択</p>
-        <div className='m-auto mt-4 h-48 rounded-lg bg-accent'>カレンダー</div>
-      </div>
-      <div className='my-8 flex justify-center font-semibold md:my-16'>
-        <Button>調整ちゃんを作成</Button>
+        <Button>調整ちゃんを入力</Button>
       </div>
     </MainLayout>
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Input } from '@/components/common'
+import { TextArea } from '@/components/common/TextArea'
 import { MainLayout } from '@/components/layout/MainLayout'
 
 export default function Home() {
@@ -9,8 +10,13 @@ export default function Home() {
         <p className='my-auto text-xl underline'>イベント名を入力</p>
         <Input />
       </div>
-      <div className='my-4 flex justify-center gap-4'>
+      <div className='mx-auto my-10 flex w-80 flex-wrap justify-center gap-4'>
         <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>
+        <p className='my-auto text-xl underline'>メモを入力</p>
+        <TextArea bordered={true} ghosted={false} />
+      </div>
+      <div className='my-4 flex justify-center gap-4'>
+        <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP3</p>
         <p className='my-auto text-xl underline'>日程の入力</p>
       </div>
       <div className='m-auto h-96 w-1/2 rounded-lg bg-accent text-center'>カレンダー</div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,7 +37,31 @@ export default function Home() {
           <TextArea bordered={true} ghosted={false} />
         </div>
       </div>
-      <div className='mt-16 flex justify-center font-semibold'>
+      <div className='m-auto mt-5 block w-4/5 md:hidden'>
+        <div className='flex gap-4'>
+          <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP1</p>
+          <p className='my-auto text-xl font-semibold'>イベント名を入力</p>
+        </div>
+        <p className='ml-16 text-sm'>※飲み会、会議など</p>
+        <div className='ml-10 mt-2'>
+          <Input />
+        </div>
+        <div className='mt-4 flex gap-4'>
+          <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP2</p>
+          <p className='my-auto text-xl font-semibold'>メモを入力(任意)</p>
+        </div>
+        <p className='ml-16 text-sm'>※出欠〆切は◯日</p>
+        <div className='ml-10 mt-2'>
+          <TextArea bordered={true} ghosted={false} />
+        </div>
+        <div className='mt-4 flex gap-4'>
+          <p className='w-fit rounded-lg bg-primary p-2 text-xl font-semibold'>STEP3</p>
+          <p className='my-auto text-xl font-semibold'>日程の入力</p>
+        </div>
+        <p className='ml-16 text-sm'>※日程調整日を選択</p>
+        <div className='m-auto mt-4 h-48 rounded-lg bg-accent'>カレンダー</div>
+      </div>
+      <div className='my-8 flex justify-center font-semibold md:my-16'>
         <Button>調整ちゃんを作成</Button>
       </div>
     </MainLayout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ export default function Home() {
       <div className='mx-auto my-10 flex w-80 flex-wrap justify-center gap-4'>
         <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP1</p>
         <p className='my-auto text-xl underline'>イベント名を入力</p>
-        <Input></Input>
+        <Input />
       </div>
       <div className='my-4 flex justify-center gap-4'>
         <p className='w-fit rounded-lg bg-primary p-2 text-xl'>STEP2</p>


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #27 

# 概要
<!-- 開発内容の概要を記載 -->
- メインページの外観を作成した。
- 機能は未実装
- フッターがabsoluteになっていたため修正した。
- inputフォームが背景と同化して見にくかったためバックグラウンドカラーを白に設定した。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="815" alt="スクリーンショット 2023-07-23 21 14 31" src="https://github.com/NUTFes/chosei-chan/assets/115447919/1f89f9f6-ed82-4ec1-b27a-71bba02f7b62">

スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `localhost:3000`にアクセスし、ページが表示されるか確認する。
- 画面が崩れていないか確認する。
- `/pages/index.js`のコードの確認。

# 備考
