### PR TITLE
[fix] textareaとinputにforwardRefを追加

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,7 +1,11 @@
+import { forwardRef, memo } from 'react'
 import { InputProps } from './Input.types'
 
-const Input: React.FC<InputProps> = (props) => {
-  return <input className='input input-bordered bg-white' {...props} />
-}
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  return <input ref={ref} className='input input-bordered bg-white' {...props} />
+})
 
-export default Input
+const [displayName] = Object.keys(Input)
+Input.displayName = displayName
+
+export default memo(Input)

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -1,12 +1,19 @@
 import classNames from 'classnames'
+import { forwardRef } from 'react'
 import { TextAreaProps } from './TextArea.types'
 
-const TextArea: React.FC<TextAreaProps> = ({ bordered, ghosted }) => {
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => {
+  const { bordered, ghosted } = props
   const borderedClass = bordered ? 'textarea-bordered' : ''
   const ghostedClass = ghosted ? 'testarea-ghost' : ''
   return (
-    <textarea className={classNames('textarea bg-white', borderedClass, ghostedClass)} />
+    <textarea
+      ref={ref}
+      className={classNames('textarea bg-white', borderedClass, ghostedClass)}
+      {...props}
+    />
   )
-}
+})
 
+TextArea.displayName = 'TextArea'
 export default TextArea


### PR DESCRIPTION
# 概要
<!-- 開発内容の概要を記載 -->

- react hook formのregisterの要素が全て渡せるようにforwardRefを追加する

# 備考
