### PR TITLE
[feat] 予定調整ページでユーザの名前表示

### DIFF
--- a/src/components/screen/MemoList/MemoList.tsx
+++ b/src/components/screen/MemoList/MemoList.tsx
@@ -8,14 +8,14 @@ const MemoList: React.FC<MemoListProps> = ({ users }) => {
     })
 
   return (
-    <div className='w-full gap-10 rounded-lg bg-white p-4 md:w-4/5 md:p-8'>
+    <div className='w-11/12 gap-10 rounded-lg bg-white p-4 md:w-4/5 md:p-8'>
       <p className='text-xl'>メモ欄</p>
       <div className='divider' />
       <div className='chat chat-start items-end gap-4'>
         {filterUsers &&
           filterUsers.map((user) => (
             <>
-              <p className='rounded-2xl bg-primary p-3 text-lg text-white md:ml-4'>
+              <p className='rounded-2xl bg-primary p-2 text-lg text-white md:ml-4 md:p-3'>
                 {user.name}
               </p>
               <div className='chat-bubble chat-bubble-secondary my-auto'>

--- a/src/pages/[scheduleId]/index.tsx
+++ b/src/pages/[scheduleId]/index.tsx
@@ -29,7 +29,7 @@ export default function Home(props: Props) {
   const router = useRouter()
   const createURL = props.id + `/create`
   const toCreate = async () => {
-    await router.push(createURL) // 遷移先のURL
+    await router.push(createURL)
   }
 
   return (
@@ -48,6 +48,16 @@ export default function Home(props: Props) {
                 参加{(schedule.users && schedule.users.length) || (!schedule.users && 0)}
                 人
               </p>
+              <div className='hidden-scrollbar flex gap-1 overflow-x-auto'>
+                {schedule.users &&
+                  schedule.users.map((user) => (
+                    <>
+                      <p className='badge badge-secondary w-full whitespace-nowrap text-white'>
+                        {user.name}
+                      </p>
+                    </>
+                  ))}
+              </div>
             </div>
             <div className='flex w-11/12 flex-col gap-4'>
               <div className='flex items-end gap-4 border-b-2 border-primary'>

--- a/src/pages/[scheduleId]/index.tsx
+++ b/src/pages/[scheduleId]/index.tsx
@@ -43,16 +43,16 @@ export default function Home(props: Props) {
                   イベント名
                 </p>
               </div>
-              <p className='break-all text-2xl'>{schedule.name}</p>
-              <p className='whitespace-nowrap text-base'>
+              <p className='text-xl md:whitespace-nowrap md:text-2xl'>{schedule.name}</p>
+              <p className='hidden whitespace-nowrap pb-1 text-base md:block'>
                 参加{(schedule.users && schedule.users.length) || (!schedule.users && 0)}
                 人
               </p>
-              <div className='hidden-scrollbar hidden gap-1 overflow-x-auto md:flex'>
+              <div className='hidden-scrollbar hidden gap-1 overflow-x-auto pb-1 md:flex'>
                 {schedule.users &&
                   schedule.users.map((user) => (
                     <>
-                      <p className='badge badge-secondary w-full whitespace-nowrap text-white'>
+                      <p className='badge badge-primary w-full whitespace-nowrap text-white'>
                         {user.name}
                       </p>
                     </>
@@ -69,6 +69,20 @@ export default function Home(props: Props) {
               <div className='flex flex-row-reverse'>
                 <ShareButton />
                 <Button onClick={toCreate}>予定を追加</Button>
+              </div>
+              <p className='block whitespace-nowrap text-base md:hidden'>
+                参加
+                {(schedule.users && schedule.users.length) || (!schedule.users && 0)}人
+              </p>
+              <div className='hidden-scrollbar flex gap-1 overflow-x-auto md:hidden'>
+                {schedule.users &&
+                  schedule.users.map((user) => (
+                    <>
+                      <p className='badge badge-primary w-full whitespace-nowrap text-white'>
+                        {user.name}
+                      </p>
+                    </>
+                  ))}
               </div>
               <div className='mx-auto flex w-full items-center justify-center'>
                 <ScheduleDisplay schedule={schedule} />

--- a/src/pages/[scheduleId]/index.tsx
+++ b/src/pages/[scheduleId]/index.tsx
@@ -78,7 +78,7 @@ export default function Home(props: Props) {
                 {schedule.users &&
                   schedule.users.map((user) => (
                     <>
-                      <p className='badge badge-primary w-full whitespace-nowrap text-white'>
+                      <p className='badge badge-primary whitespace-nowrap text-white'>
                         {user.name}
                       </p>
                     </>

--- a/src/pages/[scheduleId]/index.tsx
+++ b/src/pages/[scheduleId]/index.tsx
@@ -48,7 +48,7 @@ export default function Home(props: Props) {
                 参加{(schedule.users && schedule.users.length) || (!schedule.users && 0)}
                 人
               </p>
-              <div className='hidden-scrollbar flex gap-1 overflow-x-auto'>
+              <div className='hidden-scrollbar hidden gap-1 overflow-x-auto md:flex'>
                 {schedule.users &&
                   schedule.users.map((user) => (
                     <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,7 +77,7 @@ export default function Home() {
                 </p>
                 <p className='text-xl font-semibold'>メモを入力（任意）</p>
               </div>
-              <p className='ml-4 text-sm'>※飲み会、会議など</p>
+              <p className='ml-4 text-sm'>※参加可能な時にチェックしてください など</p>
               <TextArea bordered={true} ghosted={false} {...register('memo')} />
               <div className='divider md:hidden' />
             </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
@@ -95,9 +96,9 @@ export default function Home() {
                   setValue('dates', selectedDate)
                 }}
               />
-              {!calenderValid && (
-                <p className='text-red-500'>カレンダーを入力してください</p>
-              )}
+              <p className={classNames({ 'opacity-0': calenderValid }, 'text-red-500')}>
+                カレンダーを入力してください
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

#63 

# 概要
<!-- 開発内容の概要を記載 -->
- userの名前を予定調整ページで表示
- メインページ(入力ページ)でバリデーションの文でボタンの位置が変わってしまっていたので、固定した
- メインページ(入力ページ)の入力例を変更した


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="815" alt="スクリーンショット 2023-07-28 15 26 36" src="https://github.com/NUTFes/chosei-chan/assets/115447919/e59ae0a3-5887-4fc5-968b-52dea113e876">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 予定調整ページで人の名前が表示されるか
- [x] メインページの調整さんを作成ボタンが動かないか
- [ ] 色などは適切か
- [x] ユーザーが多い時スクロールができるか
-

# 備考
