### PR TITLE
[Fix]scheduleDisplayの色変更

### DIFF
--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -111,7 +111,7 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
         {schedule.dates.map((date, index) => (
           <>
             <div key={index}>
-              <p className='select-none whitespace-nowrap border bg-secondary-focus px-4 text-sm tracking-wider text-white md:px-10 md:text-lg'>
+              <p className='select-none whitespace-nowrap border bg-primary px-4 text-sm tracking-wider text-white md:px-10 md:py-2 md:text-lg'>
                 {format(date, 'M/d (E)')}
               </p>
               <div className='border'>

--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -79,9 +79,10 @@ function colorArrayCreate(colors: string[], max: number | undefined): string[] {
       }
     }
   } else {
-    for (let i = 1; i <= max; i++) {
+    for (let i = 1; i < max; i++) {
       newColors.push(colors[Math.ceil(i * divNumber)])
     }
+    newColors[max] = colors[colors.length - 1]
   }
   return newColors
 }
@@ -95,15 +96,19 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
 
   const max = findMaxValue(newDateSchedules)
   const bgColorDefine = [
-    'bg-white',
-    'bg-fuchsia-200',
-    'bg-fuchsia-300',
-    'bg-fuchsia-400',
-    'bg-fuchsia-500',
-    'bg-fuchsia-600',
+    'bg-opacity-100',
+    'bg-opacity-10',
+    'bg-opacity-20',
+    'bg-opacity-30',
+    'bg-opacity-40',
+    'bg-opacity-50',
+    'bg-opacity-60',
+    'bg-opacity-70',
+    'bg-opacity-80',
+    'bg-opacity-90',
+    'bg-opacity-100',
   ]
   const colors = colorArrayCreate(bgColorDefine, max)
-
   return (
     <div className='overflow-x-scroll rounded-lg'>
       <div className='flex items-center p-1 md:p-2'>
@@ -118,7 +123,12 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
                 {newDates[index].map((time, index) => (
                   <>
                     <div
-                      className={classNames(colors[newDateSchedules[time]], 'h-2 md:h-3')}
+                      className={classNames(
+                        colors[newDateSchedules[time]],
+                        { 'bg-pink-600': newDateSchedules[time] },
+                        { 'bg-white': !newDateSchedules[time] },
+                        'h-2 md:h-3',
+                      )}
                       key={time}
                     >
                       <p


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#66 

# 概要
<!-- 開発内容の概要を記載 -->
- 元々の色は不評だったので変更した
- 色をopacityによって変更する

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![スクリーンショット 2023-07-28 20 46 55](https://github.com/NUTFes/chosei-chan/assets/115447919/af1caf79-6c96-4cd6-a5e8-278a56a2818e)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 表示が問題ないか
- 
-

# 備考
