### PR TITLE
[feat]calenderDisplayホバー時に名前を表示

### DIFF
--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -109,35 +109,51 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
       <div className='flex items-center p-1 md:p-2'>
         <div className='flex flex-col'>{}</div>
         {schedule.dates.map((date, index) => (
-          <>
-            <div key={index}>
-              <p className='select-none whitespace-nowrap border bg-secondary-focus px-4 text-sm tracking-wider text-white md:px-10 md:text-lg'>
-                {format(date, 'M/d (E)')}
-              </p>
-              <div className='border'>
-                {newDates[index].map((time, index) => (
-                  <>
-                    <div
-                      className={classNames(colors[newDateSchedules[time]], 'h-2 md:h-3')}
-                      key={time}
+          <div key={index}>
+            <p className='select-none whitespace-nowrap border bg-secondary-focus px-4 text-sm tracking-wider text-white md:px-10 md:text-lg'>
+              {format(date, 'M/d (E)')}
+            </p>
+            <div className='border'>
+              {newDates[index].map((time, index) => {
+                const selectedUsers = schedule.users
+                  ? schedule.users.filter(
+                      (user) =>
+                        user.availables?.some(
+                          (available) => time >= available.from && time < available.to,
+                        ),
+                    )
+                  : []
+
+                const tooltipContent =
+                  selectedUsers.length > 0
+                    ? selectedUsers.map((user) => user.name).join(', ')
+                    : ''
+
+                return (
+                  <div
+                    className={classNames(
+                      colors[newDateSchedules[time]],
+                      'tooltip h-2 md:h-3 flex',
+                      { 'no-tooltip': selectedUsers.length === 0 },
+                    )}
+                    data-tip={tooltipContent}
+                    key={time}
+                  >
+                    <p
+                      className={classNames(
+                        { hidden: !(index % 2 == 0) },
+                        { 'text-lime-50': newDateSchedules[time] },
+                        { 'text-gray-300': !newDateSchedules[time] },
+                        'text-xs select-none',
+                      )}
                     >
-                      <p
-                        className={classNames(
-                          { hidden: !(index % 2 == 0) },
-                          { 'text-lime-50': newDateSchedules[time] },
-                          { 'text-gray-300': !newDateSchedules[time] },
-                          'text-xs select-none',
-                        )}
-                      >
-                        {format(time, 'HH:mm')}
-                      </p>
-                    </div>
-                    <hr className={classNames({ hidden: index % 2 == 0 })}></hr>
-                  </>
-                ))}
-              </div>
+                      {format(time, 'HH:mm')}
+                    </p>
+                  </div>
+                )
+              })}
             </div>
-          </>
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -140,7 +140,7 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
                       colors[newDateSchedules[time]],
                       { 'bg-pink-600': newDateSchedules[time] },
                       { 'bg-white': !newDateSchedules[time] },
-                      'tooltip h-2 md:h-3 flex',
+                      'tooltip h-4 flex',
                       { 'no-tooltip': selectedUsers.length === 0 },
                     )}
                     data-tip={tooltipContent}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,4 +11,7 @@
       /* Chrome, Safari 対応 */
       display: none;
     }
+    .no-tooltip {
+      pointer-events: none; /* tooltipのイベントを無効化 */
+    }
   }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #61

# 概要
<!-- 開発内容の概要を記載 -->
- daisyUIのtooltipを使用してホバー時にメッセージを表示
- メッセージに選択した人の名前を表示


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="1440" alt="スクリーンショット 2023-07-28 21 02 44" src="https://github.com/NUTFes/chosei-chan/assets/107479066/2ca1d847-a509-4761-ac6d-b3905f4c741d">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 上記の表示ができている
- [x] 選択している人がいないところはメッセージが表示されない
- [x] 選択している人によって表示数もかわる

# 備考
