### PR TITLE
[feat]scheduleをCarouselで表示する

### DIFF
--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -111,16 +111,17 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
   const colors = colorArrayCreate(bgColorDefine, max)
   return (
     <div className='overflow-x-scroll rounded-lg'>
-      <div className='flex items-center'>
+      <div className='carousel flex items-center'>
         {schedule.dates.map((date, index) => (
-          <div key={index} className='flex flex-col'>
+          <div key={index} className='carousel-item flex w-screen flex-col md:w-48'>
             <div>
-              <div className='ml-auto w-12 translate-y-2 rounded-lg bg-neutral px-2 py-1 text-center text-sm text-white'>
+              <div className='ml-auto hidden translate-y-2 rounded-lg bg-neutral px-2 py-1 text-center text-sm text-white md:block md:w-12'>
                 {format(date, 'E')}
               </div>
-              <p className='select-none whitespace-nowrap rounded-t-xl border-x bg-primary px-10 py-2 text-lg tracking-wider text-white'>
-                {format(date, 'M / d')}
-              </p>
+              <div className='mx-auto flex select-none justify-center whitespace-nowrap rounded-t-xl border-x bg-primary px-10 py-2 tracking-wider text-white'>
+                <p className='text-3xl  md:text-lg'>{format(date, 'M / d')}</p>
+                <p className='text-3xl md:hidden'>({format(date, 'E')})</p>
+              </div>
             </div>
             <div>
               {newDates[index].map((time, dates_index) => {
@@ -146,7 +147,6 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
                         colors[newDateSchedules[time]],
                         { 'bg-pink-600': newDateSchedules[time] },
                         { 'bg-white': !newDateSchedules[time] },
-                        'h-4',
                         'tooltip h-4 flex',
                         { 'no-tooltip': selectedUsers.length === 0 },
                       )}
@@ -156,12 +156,13 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
                       <p
                         className={classNames(
                           { hidden: !(dates_index % 2 == 0) },
+                          { 'md:hidden': !(index === 0) },
                           { 'text-primary-content': newDateSchedules[time] },
                           { 'text-neutral': !newDateSchedules[time] },
-                          'text-xs select-none absolute left-0',
+                          'text-xs select-none absolute left-0 ml-2',
                         )}
                       >
-                        {index === 0 && format(time, 'HH:mm')}
+                        {format(time, 'HH:mm')}
                       </p>
                     </div>
                     <hr className={classNames({ hidden: dates_index % 2 == 0 })} />

--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -119,8 +119,8 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
                 {format(date, 'E')}
               </div>
               <div className='mx-auto flex select-none justify-center whitespace-nowrap rounded-t-xl border-x bg-primary px-10 py-2 tracking-wider text-white'>
-                <p className='text-3xl  md:text-lg'>{format(date, 'M / d')}</p>
-                <p className='text-3xl md:hidden'>({format(date, 'E')})</p>
+                <p className='text-xl  md:text-lg'>{format(date, 'M / d')}</p>
+                <p className='ml-3 text-xl md:hidden'>({format(date, 'E')})</p>
               </div>
             </div>
             <div>

--- a/src/components/screen/ScheduleInput/ScheduleInput.tsx
+++ b/src/components/screen/ScheduleInput/ScheduleInput.tsx
@@ -79,7 +79,7 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
   }, [submitAvailableDates])
 
   return (
-    <div className='carousel flex w-full rounded-lg bg-white p-8 pl-24'>
+    <div className='carousel flex w-full gap-1 rounded-lg bg-white p-8 pl-24'>
       {schedule.dates.map((date, dateIndex) => {
         const dividedDay = dayDivideQuarterHour(date)
         return (
@@ -87,8 +87,8 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
             key={date}
             className='carousel-item flex w-screen shrink-0 flex-col items-center gap-4 md:w-48'
           >
-            <div className='flex w-2/3 justify-center rounded-md bg-primary px-2 py-1'>
-              <p className='text-lg font-semibold text-white'>
+            <div className='flex w-screen justify-center rounded-t-xl bg-primary px-2 py-1 md:w-11/12 md:rounded-xl'>
+              <p className='w-screen py-1 text-center text-xl text-white'>
                 {format(date, 'M/d (E)')}
               </p>
             </div>

--- a/src/components/screen/ScheduleInput/ScheduleInput.tsx
+++ b/src/components/screen/ScheduleInput/ScheduleInput.tsx
@@ -79,13 +79,18 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
   }, [submitAvailableDates])
 
   return (
-    <div className='flex w-full overflow-x-scroll rounded-lg bg-white p-8 pl-24'>
+    <div className='carousel flex w-full rounded-lg bg-white p-8 pl-24'>
       {schedule.dates.map((date, dateIndex) => {
         const dividedDay = dayDivideQuarterHour(date)
         return (
-          <div key={date} className='flex w-48 shrink-0 flex-col items-center gap-4'>
+          <div
+            key={date}
+            className='carousel-item flex w-screen shrink-0 flex-col items-center gap-4 md:w-48'
+          >
             <div className='flex w-2/3 justify-center rounded-md bg-primary px-2 py-1'>
-              <p className='text-lg font-bold text-white'>{format(date, 'M/d')}</p>
+              <p className='text-lg font-semibold text-white'>
+                {format(date, 'M/d (E)')}
+              </p>
             </div>
             <div
               className={classNames(

--- a/src/pages/[scheduleId]/create.tsx
+++ b/src/pages/[scheduleId]/create.tsx
@@ -98,6 +98,8 @@ export default function Create(props: Props) {
                   </div>
                 </div>
               </div>
+            </div>
+            <div className='flex w-screen flex-col gap-8'>
               <ScheduleInput
                 schedule={schedule}
                 onChange={(availableDates: Available[] | null) => {

--- a/src/pages/[scheduleId]/index.tsx
+++ b/src/pages/[scheduleId]/index.tsx
@@ -52,7 +52,7 @@ export default function Home(props: Props) {
                 {schedule.users &&
                   schedule.users.map((user) => (
                     <>
-                      <p className='badge badge-outline badge-neutral w-full whitespace-nowrap'>
+                      <p className='badge badge-neutral badge-outline w-full whitespace-nowrap'>
                         {user.name}
                       </p>
                     </>
@@ -87,13 +87,15 @@ export default function Home(props: Props) {
                 {schedule.users &&
                   schedule.users.map((user) => (
                     <>
-                      <p className='badge badge-neutral whitespace-nowrap'>{user.name}</p>
+                      <p className='badge badge-neutral badge-outline whitespace-nowrap'>
+                        {user.name}
+                      </p>
                     </>
                   ))}
               </div>
-              <div className='mx-auto flex w-full items-center justify-center'>
-                <ScheduleDisplay schedule={schedule} />
-              </div>
+            </div>
+            <div className='mx-auto flex w-screen items-center justify-center md:w-11/12'>
+              <ScheduleDisplay schedule={schedule} />
             </div>
             <div className='flex w-full items-center justify-center'>
               <MemoList users={schedule.users} />


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #80 

# 概要
<!-- 開発内容の概要を記載 -->
- scheduleをcarouselで表示しrた
- daigyUIの[carousel](https://daisyui.com/components/carousel/)

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
<img width="1173" alt="スクリーンショット 2023-07-29 6 25 53" src="https://github.com/NUTFes/chosei-chan/assets/115447919/9c814500-3223-4000-9b93-9834aba7a02e">
<img width="1178" alt="スクリーンショット 2023-07-29 6 27 00" src="https://github.com/NUTFes/chosei-chan/assets/115447919/700821a9-172b-439a-a0ef-a13f486f8f13">
<img width="363" alt="スクリーンショット 2023-07-29 6 26 22" src="https://github.com/NUTFes/chosei-chan/assets/115447919/e4036152-b7d9-4168-8d4b-ebcc93e73859">
<img width="382" alt="スクリーンショット 2023-07-29 7 25 53" src="https://github.com/NUTFes/chosei-chan/assets/115447919/aae89694-7be3-4b6c-8d2c-c36d9af11b72">




# テスト項目
<!-- テストしてほしい内容を記載 -->
- 予定調整ページと予定入力ページの動作が正常か
- デザインがいいか、(pc,sp版)

# 備考
- あんまりだったらmergeしなくてもいいです