### PR TITLE
fix: モバイル対応とドラッグ挙動の修正

### DIFF
--- a/src/components/screen/Calender/Calender.tsx
+++ b/src/components/screen/Calender/Calender.tsx
@@ -44,7 +44,9 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
   }
 
   const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>, date: Date) => {
-    e.currentTarget.releasePointerCapture(e.pointerId)
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
     const t = date.getTime()
     dragMode.current = selectedDates.includes(t) ? 'deselect' : 'select'
     isDragging.current = true
@@ -54,6 +56,12 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
   const handlePointerEnter = (date: Date) => {
     if (!isDragging.current) return
     dragMode.current === 'select' ? selectDate(date) : deselectDate(date)
+  }
+
+  const handleKeyboardClick = (e: React.MouseEvent, date: Date) => {
+    if (e.detail !== 0) return
+    const t = date.getTime()
+    selectedDates.includes(t) ? deselectDate(date) : selectDate(date)
   }
 
   const handlePreviousMonth = () => {
@@ -73,7 +81,11 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
       isDragging.current = false
     }
     document.addEventListener('pointerup', stop)
-    return () => document.removeEventListener('pointerup', stop)
+    document.addEventListener('pointercancel', stop)
+    return () => {
+      document.removeEventListener('pointerup', stop)
+      document.removeEventListener('pointercancel', stop)
+    }
   }, [])
 
   return (
@@ -117,6 +129,7 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
                       type='button'
                       onPointerDown={(e) => handlePointerDown(e, date)}
                       onPointerEnter={() => handlePointerEnter(date)}
+                      onClick={(e) => handleKeyboardClick(e, date)}
                       style={{ touchAction: 'none' }}
                       className={classNames(
                         'btn btn-circle btn-outline h-10 min-h-fit w-10 min-w-fit select-none md:btn-md',

--- a/src/components/screen/Calender/Calender.tsx
+++ b/src/components/screen/Calender/Calender.tsx
@@ -12,13 +12,15 @@ import {
   startOfMonth,
   endOfMonth,
 } from 'date-fns'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md'
 import { CalenderProps } from './Calender.types'
 
 const Calender: React.FC<CalenderProps> = ({ onChange }) => {
   const [targetMonth, setTargetMonth] = useState(new Date())
   const [selectedDates, setSelectedDates] = useState<number[]>([])
+  const isDragging = useRef(false)
+  const dragMode = useRef<'select' | 'deselect'>('select')
 
   const getCalenderArray = (date: Date) => {
     const sundays = eachWeekOfInterval({
@@ -31,15 +33,27 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
   }
   const calender = getCalenderArray(targetMonth)
 
-  const handleDateClick = (date: Date) => {
-    const unixTime = date.getTime()
-    setSelectedDates((prevDates) => {
-      if (prevDates.includes(unixTime)) {
-        return prevDates.filter((time) => time !== unixTime).sort()
-      } else {
-        return [...prevDates, unixTime].sort()
-      }
-    })
+  const selectDate = (date: Date) => {
+    const t = date.getTime()
+    setSelectedDates((prev) => (prev.includes(t) ? prev : [...prev, t].sort()))
+  }
+
+  const deselectDate = (date: Date) => {
+    const t = date.getTime()
+    setSelectedDates((prev) => prev.filter((x) => x !== t).sort())
+  }
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>, date: Date) => {
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    const t = date.getTime()
+    dragMode.current = selectedDates.includes(t) ? 'deselect' : 'select'
+    isDragging.current = true
+    dragMode.current === 'select' ? selectDate(date) : deselectDate(date)
+  }
+
+  const handlePointerEnter = (date: Date) => {
+    if (!isDragging.current) return
+    dragMode.current === 'select' ? selectDate(date) : deselectDate(date)
   }
 
   const handlePreviousMonth = () => {
@@ -53,6 +67,12 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
   useEffect(() => {
     onChange(selectedDates)
   }, [selectedDates])
+
+  useEffect(() => {
+    const stop = () => { isDragging.current = false }
+    document.addEventListener('pointerup', stop)
+    return () => document.removeEventListener('pointerup', stop)
+  }, [])
 
   return (
     <div className='flex-col'>
@@ -93,14 +113,11 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
                   <td key={getDay(date)} className='pt-1 text-center md:px-1'>
                     <button
                       type='button'
-                      draggable
-                      onClick={() => handleDateClick(date)}
-                      onDragEnter={(e) => {
-                        handleDateClick(date)
-                        e.preventDefault()
-                      }}
+                      onPointerDown={(e) => handlePointerDown(e, date)}
+                      onPointerEnter={() => handlePointerEnter(date)}
+                      style={{ touchAction: 'none' }}
                       className={classNames(
-                        'btn btn-circle btn-outline h-10 min-h-fit w-10 min-w-fit md:btn-md',
+                        'btn btn-circle btn-outline h-10 min-h-fit w-10 min-w-fit select-none md:btn-md',
                         isSelected ? 'btn-active' : '',
                       )}
                     >

--- a/src/components/screen/Calender/Calender.tsx
+++ b/src/components/screen/Calender/Calender.tsx
@@ -69,7 +69,9 @@ const Calender: React.FC<CalenderProps> = ({ onChange }) => {
   }, [selectedDates])
 
   useEffect(() => {
-    const stop = () => { isDragging.current = false }
+    const stop = () => {
+      isDragging.current = false
+    }
     document.addEventListener('pointerup', stop)
     return () => document.removeEventListener('pointerup', stop)
   }, [])

--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -126,11 +126,10 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
             <div>
               {newDates[index].map((time, dates_index) => {
                 const selectedUsers = schedule.users
-                  ? schedule.users.filter(
-                      (user) =>
-                        user.availables?.some(
-                          (available) => time >= available.from && time < available.to,
-                        ),
+                  ? schedule.users.filter((user) =>
+                      user.availables?.some(
+                        (available) => time >= available.from && time < available.to,
+                      ),
                     )
                   : []
 

--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -126,10 +126,11 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
             <div>
               {newDates[index].map((time, dates_index) => {
                 const selectedUsers = schedule.users
-                  ? schedule.users.filter((user) =>
-                      user.availables?.some(
-                        (available) => time >= available.from && time < available.to,
-                      ),
+                  ? schedule.users.filter(
+                      (user) =>
+                        user.availables?.some(
+                          (available) => time >= available.from && time < available.to,
+                        ),
                     )
                   : []
 

--- a/src/components/screen/ScheduleInput/ScheduleInput.tsx
+++ b/src/components/screen/ScheduleInput/ScheduleInput.tsx
@@ -77,7 +77,9 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
   }
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>, time: number) => {
-    e.currentTarget.releasePointerCapture(e.pointerId)
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
     dragMode.current = selectedTimes.includes(time) ? 'deselect' : 'select'
     isDragging.current = true
     dragMode.current === 'select' ? selectTime(time) : deselectTime(time)
@@ -88,12 +90,21 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
     dragMode.current === 'select' ? selectTime(time) : deselectTime(time)
   }
 
+  const handleKeyboardClick = (e: React.MouseEvent, time: number) => {
+    if (e.detail !== 0) return
+    selectedTimes.includes(time) ? deselectTime(time) : selectTime(time)
+  }
+
   useEffect(() => {
     const stop = () => {
       isDragging.current = false
     }
     document.addEventListener('pointerup', stop)
-    return () => document.removeEventListener('pointerup', stop)
+    document.addEventListener('pointercancel', stop)
+    return () => {
+      document.removeEventListener('pointerup', stop)
+      document.removeEventListener('pointercancel', stop)
+    }
   }, [])
 
   useEffect(() => {
@@ -130,6 +141,7 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
                   style={{ touchAction: 'pan-x' }}
                   onPointerDown={(e) => handlePointerDown(e, time)}
                   onPointerEnter={() => handlePointerEnter(time)}
+                  onClick={(e) => handleKeyboardClick(e, time)}
                 >
                   {timeIndex % 2 === 0 && <p className='w-12 -translate-x-6 border-t' />}
                   {timeIndex % 2 === 0 && dateIndex === 0 && (

--- a/src/components/screen/ScheduleInput/ScheduleInput.tsx
+++ b/src/components/screen/ScheduleInput/ScheduleInput.tsx
@@ -89,7 +89,9 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
   }
 
   useEffect(() => {
-    const stop = () => { isDragging.current = false }
+    const stop = () => {
+      isDragging.current = false
+    }
     document.addEventListener('pointerup', stop)
     return () => document.removeEventListener('pointerup', stop)
   }, [])

--- a/src/components/screen/ScheduleInput/ScheduleInput.tsx
+++ b/src/components/screen/ScheduleInput/ScheduleInput.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import format from 'date-fns/format'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ScheduleInputProps } from './ScheduleInput.types'
 import { Available } from '@/type/common'
 import { dayDivideQuarterHour } from '@/utils/dayDivideHalfHour'
@@ -25,6 +25,8 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
     }, [])
   }, [editUser])
   const [selectedTimes, setSelectedTimes] = useState<number[]>(initialSelectedTimes)
+  const isDragging = useRef(false)
+  const dragMode = useRef<'select' | 'deselect'>('select')
 
   const otherUserSelectedTimes = useMemo(() => {
     if (!schedule.users) return []
@@ -66,13 +68,31 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
     }, [])
   }, [selectedTimes])
 
-  const handleSelectedTimes = (selectedTime: number) => {
-    setSelectedTimes((prev) => {
-      const index = prev.findIndex((prevTime) => prevTime === selectedTime)
-      if (index === -1) return [...prev, selectedTime]
-      return prev.filter((_, i) => i !== index)
-    })
+  const selectTime = (time: number) => {
+    setSelectedTimes((prev) => (prev.includes(time) ? prev : [...prev, time]))
   }
+
+  const deselectTime = (time: number) => {
+    setSelectedTimes((prev) => prev.filter((t) => t !== time))
+  }
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>, time: number) => {
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    dragMode.current = selectedTimes.includes(time) ? 'deselect' : 'select'
+    isDragging.current = true
+    dragMode.current === 'select' ? selectTime(time) : deselectTime(time)
+  }
+
+  const handlePointerEnter = (time: number) => {
+    if (!isDragging.current) return
+    dragMode.current === 'select' ? selectTime(time) : deselectTime(time)
+  }
+
+  useEffect(() => {
+    const stop = () => { isDragging.current = false }
+    document.addEventListener('pointerup', stop)
+    return () => document.removeEventListener('pointerup', stop)
+  }, [])
 
   useEffect(() => {
     if (onChange) onChange(submitAvailableDates)
@@ -101,17 +121,13 @@ const ScheduleInput: React.FC<ScheduleInputProps> = ({
               {dividedDay.map((time, timeIndex) => (
                 <div
                   key={time}
-                  className={classNames('h-6', {
+                  className={classNames('h-6 select-none', {
                     'bg-secondary': selectedTimes.includes(time),
                     'bg-primary': otherUserSelectedTimes.includes(time),
                   })}
-                  draggable
-                  onDragEnter={() => {
-                    handleSelectedTimes(time)
-                  }}
-                  onClick={() => {
-                    handleSelectedTimes(time)
-                  }}
+                  style={{ touchAction: 'pan-x' }}
+                  onPointerDown={(e) => handlePointerDown(e, time)}
+                  onPointerEnter={() => handlePointerEnter(time)}
                 >
                   {timeIndex % 2 === 0 && <p className='w-12 -translate-x-6 border-t' />}
                   {timeIndex % 2 === 0 && dateIndex === 0 && (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,14 @@
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
+import Head from 'next/head'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Head>
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  )
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,9 @@ import { Html, Head, Main, NextScript } from 'next/document'
 export default function Document() {
   return (
     <Html lang='en'>
-      <Head />
+      <Head>
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,9 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document'
 export default function Document() {
   return (
     <Html lang='en'>
-      <Head>
-        <meta name='viewport' content='width=device-width, initial-scale=1' />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
## 概要

カレンダー・時間帯選択のドラッグ操作をモバイル対応させ、PCでのバグも修正します。

## 問題の原因

### スマホで操作できない
HTML5 Drag API (`draggable` 属性 + `onDragEnter`) はタッチデバイスでは動作しません。そのため、スマホでは複数の日付・時間帯をスワイプ選択できませんでした。

### PCでドラッグがバグる
`handleDateClick` / `handleSelectedTimes` が**トグル**（選択/解除を切り替える）する実装のため、ドラッグ中にすでに選択済みのセルを通過すると意図せず解除されていました。また、ドラッグ開始時に「選択モード」か「解除モード」かを決定する仕組みがありませんでした。

## 修正内容

### `Calender.tsx` / `ScheduleInput.tsx`
- HTML5 Drag API を **Pointer Events API** (`onPointerDown` + `onPointerEnter`) に置き換え
  - マウスとタッチの両方で動作
  - `releasePointerCapture` を呼ぶことでタッチ時も指の移動先で `onPointerEnter` が発火するようになる
- ドラッグ開始時点で**モード（select / deselect）を決定**し、ドラッグ中は一貫して同じ操作を適用
- カレンダー: `touchAction: none` でドラッグ中の意図しないスクロールを防止
- 時間帯: `touchAction: pan-x` でカルーセルの横スクロールは維持しつつ縦ドラッグを有効化

### `_document.tsx`
- `<meta name="viewport">` タグを追加してモバイル端末での表示スケールを正常化

## テスト方法

- [ ] PC: カレンダーで複数日付をドラッグ選択 → 一方向（選択のみ or 解除のみ）で動作すること
- [ ] PC: 時間帯を上下ドラッグで複数選択/解除できること
- [ ] スマホ/タッチエミュレーション: カレンダーで指をスワイプして複数日付を選択できること
- [ ] スマホ/タッチエミュレーション: 時間帯を縦ドラッグで複数選択できること
- [ ] スマホ: 時間帯エリアを横スワイプして日付カルーセルが切り替わること
- [ ] 単一クリック/タップで個別選択/解除が動作すること

https://claude.ai/code/session_012FciD1Zcpc5vsi2xggJzYg

---
_Generated by [Claude Code](https://claude.ai/code/session_012FciD1Zcpc5vsi2xggJzYg)_