### PR TITLE
[codex] Fix prettier workflow formatting mismatch

### DIFF
--- a/.github/workflows/auto-prettier.yml
+++ b/.github/workflows/auto-prettier.yml
@@ -13,10 +13,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
       - name: Run Prettier
         run: |
           npx prettier --write ${FILE_PATTERN}

--- a/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
+++ b/src/components/screen/ScheduleDisplay/ScheduleDisplay.tsx
@@ -126,10 +126,11 @@ const ScheduleDisplay: React.FC<ScheduleDisplayProps> = ({ schedule }) => {
             <div>
               {newDates[index].map((time, dates_index) => {
                 const selectedUsers = schedule.users
-                  ? schedule.users.filter((user) =>
-                      user.availables?.some(
-                        (available) => time >= available.from && time < available.to,
-                      ),
+                  ? schedule.users.filter(
+                      (user) =>
+                        user.availables?.some(
+                          (available) => time >= available.from && time < available.to,
+                        ),
                     )
                   : []
 


### PR DESCRIPTION
## Summary

Fixes the `ScheduleDisplay.tsx` Prettier formatting error again and updates the auto-prettier workflow so it uses the repository's locked dependencies.

## Root cause

The previous fix was pushed correctly, but `.github/workflows/auto-prettier.yml` ran `npx prettier --write` without installing project dependencies. That used a different Prettier setup from the repo and added an `Apply Prettier Change` commit that reverted the formatting fix before the PR was merged.

## Impact

- Keeps `ScheduleDisplay.tsx` formatted in the way `next lint` expects.
- Makes the auto-prettier workflow install dependencies with `npm ci`, so it uses the repo's configured Prettier and plugins.
- Runtime behavior is unchanged.

## Validation

- `npx prettier --write "src/**/*.{ts,tsx,js,jsx}"`
- `npm run lint`
- `npm run build`
- GitHub Actions `Prettier` workflow passed on this branch without adding a follow-up commit: https://github.com/NUTFes/chosei-chan/actions/runs/28647747749